### PR TITLE
Split src and test using tsc --build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .tool-versions
 .npmrc
 *~
+tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -12,16 +12,12 @@
   "source": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "src"
-  ],
   "scripts": {
     "build": "npm run buildonly",
-    "buildonly": "tsc",
+    "buildonly": "tsc -b --verbose .",
     "test": "echo 'tested in post-build'",
-    "postbuild": "NODE_OPTIONS=--experimental-vm-modules jest src/postbuild.test.ts",
-    "lint": "eslint src --ext .ts",
+    "postbuild": "NODE_OPTIONS=--experimental-vm-modules jest test/postbuild.test.ts",
+    "lint": "eslint src test --ext .ts",
     "prebuild": "npm run test",
     "pretest": "npm run lint",
     "lint:fix": "npm run lint -- --fix",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "..",
+  "include": ["./**.ts"],
+  "compilerOptions": {
+    "outDir": "../dist"
+  }
+}

--- a/test/expect.ts
+++ b/test/expect.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { extend } from '..';
+import { extend } from '../src';
 
 import { fileMatchers } from './file';
 import { processMatchers } from './process';

--- a/test/file.ts
+++ b/test/file.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs';
 
-import type { MatchersFor, MatcherState, ExpectationResult } from '..';
+import type { MatchersFor, MatcherState, ExpectationResult } from '../src';
 
 function isAFile(
     this: MatcherState,

--- a/test/postbuild.test.ts
+++ b/test/postbuild.test.ts
@@ -24,7 +24,7 @@ import { spawn } from 'child_process';
 import semver from 'semver';
 import { describe, it } from '@jest/globals';
 
-import { expect } from './test/expect';
+import { expect } from './expect';
 
 type PackageFile = {
     source?: string;
@@ -120,7 +120,16 @@ itNonRecursive(
         await expect(
             spawn(
                 'cp',
-                ['-r', 'src', '.ed*', '.es*', 'jest*', 'tsconfig*', dir],
+                [
+                    '-r',
+                    'src',
+                    'test',
+                    '.ed*',
+                    '.es*',
+                    'jest*',
+                    'tsconfig*',
+                    dir,
+                ],
                 {
                     stdio: 'inherit',
                     shell: true,

--- a/test/process.ts
+++ b/test/process.ts
@@ -16,7 +16,7 @@
 
 import { ChildProcess } from 'child_process';
 
-import type { ExpectationResult, MatchersFor, MatcherState } from '..';
+import type { ExpectationResult, MatchersFor, MatcherState } from '../src';
 
 async function toSpawnSuccessfully(
     this: MatcherState,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "..",
+  "include": ["./**.ts"],
+  "references": [
+    {
+      "path": "../src"
+    }
+  ],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,21 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src"],
-  "exclude": ["**/*.test.ts", "**/test/**"],
   "extends": "@tsconfig/node16/tsconfig.json",
+  "references": [
+    {
+      "path": "src"
+    },
+    {
+      "path": "test"
+    }
+  ],
+  "files": [],
   "compilerOptions": {
+    "composite": true,
     "module": "ESNext",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
-    "rootDir": "./src",
-    "outDir": "./dist",
     // linter checks for common issues
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Not a huge change in _this_ project, but more cleanly splits things up and ensures we are actually checking our test files -- by excluding them previously, we weren't type checking them in the build step.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>