### PR TITLE
Avoid depending on Jest itself at run-time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-jest": "27.4.0",
         "expect": "29.7.0",
         "jest": "29.7.0",
+        "prepackage-checks": "0.1.2",
         "prettier": "3.0.3",
         "semver": "7.5.4",
         "ts-jest": "29.1.1",
@@ -3610,6 +3611,20 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/extend-expect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/extend-expect/-/extend-expect-1.1.0.tgz",
+      "integrity": "sha512-GbJ+CAeNbaHjEAubqKvgiVXc4Mt1BUa56bLphFRcPWHDL4gpOPp8IAsdr6bonizmeyduDH9Z9ndIj1n5wKtCgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^28 || ^29",
+        "expect": "^28 || ^29",
+        "jest-matcher-utils": "^28 || ^29"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5835,6 +5850,60 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepackage-checks": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/prepackage-checks/-/prepackage-checks-0.1.2.tgz",
+      "integrity": "sha512-oXmr04GrYw6S9gAyi6ZBsPsCsKxcB9naxLxTN9AW6kaFtSNUqMr03A7CoE3+FZM84N7hQ4otxk+cuBg1nX3ZEg==",
+      "dev": true,
+      "dependencies": {
+        "extend-expect": "^1.0.2",
+        "glob": "^8.0.3",
+        "jest": "^29.0.3"
+      },
+      "bin": {
+        "prepackage-checks": "dist/cli.js"
+      }
+    },
+    "node_modules/prepackage-checks/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/prepackage-checks/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prepackage-checks/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -18,14 +18,16 @@
   "scripts": {
     "build": "npm run buildonly",
     "buildonly": "tsc -b --verbose .",
-    "test": "echo 'tested in post-build'",
-    "postbuild": "NODE_OPTIONS=--experimental-vm-modules jest test/postbuild.test.ts",
+    "clean": "rm -rf build dist",
+    "dev": "npm run lint:fix && npm run build",
     "lint": "eslint .",
-    "prebuild": "npm run test",
-    "pretest": "npm run lint",
     "lint:fix": "npm run lint -- --fix",
-    "dev": "npm run lint:fix && npm run buildonly && npm run test",
-    "prepublishOnly": "npm run build"
+    "postbuild": "npm run test",
+    "postinstall": "npm run buildonly",
+    "posttest": "prepackage-checks",
+    "prepublishOnly": "npm run clean && npm run build",
+    "pretest": "npm run lint",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest test/postbuild.test.ts"
   },
   "prettier": {
     "semi": true,
@@ -43,6 +45,7 @@
     "eslint-plugin-jest": "27.4.0",
     "expect": "29.7.0",
     "jest": "29.7.0",
+    "prepackage-checks": "0.1.2",
     "prettier": "3.0.3",
     "semver": "7.5.4",
     "ts-jest": "29.1.1",
@@ -50,7 +53,6 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "@jest/globals": "^28 || ^29",
     "expect": "^28 || ^29",
     "jest-matcher-utils": "^28 || ^29"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { expect as originalExpect } from '@jest/globals';
+import { expect as originalExpect } from 'expect';
 
 import type {
     Expect as RawExpect,

--- a/test/postbuild.test.ts
+++ b/test/postbuild.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { readFileSync } from 'fs';
-import * as fs from 'fs';
-import { promisify } from 'util';
-import * as os from 'os';
-import * as path from 'path';
-import { spawn } from 'child_process';
+import { readFileSync } from 'node:fs';
+import * as fs from 'node:fs';
+import { promisify } from 'node:util';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
 
 import semver from 'semver';
 import { describe, it } from '@jest/globals';
@@ -97,8 +97,10 @@ itNonRecursive(
                 devDependencies[key] = value;
             }
         }
+        const version = PACKAGE_JSON['version'] + '-downgrade-build';
         const packageJson: PackageFile = {
             ...PACKAGE_JSON,
+            version,
             dependencies,
             devDependencies,
             peerDependencies,
@@ -113,9 +115,6 @@ itNonRecursive(
         );
         console.log(`Working in: ${dir}`);
 
-        await expect(
-            spawn('npm', ['install'], { cwd: dir, stdio: 'inherit' }),
-        ).toSpawnSuccessfully();
         await expect(
             spawn(
                 'cp',
@@ -136,7 +135,14 @@ itNonRecursive(
             ),
         ).toSpawnSuccessfully();
         await expect(
-            spawn('npm', ['run', 'build'], {
+            spawn('npm', ['install'], {
+                cwd: dir,
+                stdio: 'inherit',
+                env: { ...process.env, [POST_BUILD_TESTS]: '1' },
+            }),
+        ).toSpawnSuccessfully();
+        await expect(
+            spawn('npm', ['run', 'buildonly'], {
                 cwd: dir,
                 stdio: 'inherit',
                 env: { ...process.env, [POST_BUILD_TESTS]: '1' },


### PR DESCRIPTION
We can use 'expect' directly, which means we can run outside a Jest environment.