### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.github
+build
+.idea
+.tool-versions
+*~


### PR DESCRIPTION
Somehow 1.x packages contained the dist directory but 2.0.0 doesn't.